### PR TITLE
Add AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Repo Guidelines
+
+## Coding style
+- Use 4 spaces for indentation in Python.
+- Keep line length under 100 characters.
+- Document new functions and classes with docstrings.
+
+## Testing
+- Run `pytest` from the repository root before each commit.
+
+## Commit messages
+- Use concise commit summaries under 72 characters.
+- Mention the component or module being changed when possible.
+
+## Pull Request messages
+- Provide a short summary of changes.
+- Include a testing section stating whether `pytest` succeeded.


### PR DESCRIPTION
## Summary
- document repo guidelines and testing instructions in new `AGENTS.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'okane')*
- `pip install -r src/python/requirements.txt` *(fails to build pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6844e15621808333948e60a7ccc1354a